### PR TITLE
Fix line wrapping for long lines with no whitespace

### DIFF
--- a/howzit
+++ b/howzit
@@ -88,9 +88,11 @@ module BuildNotes
         at = line.index(/\s/, last_at + 1)
       end
 
-      last_at = width if last_at.nil?
-
-      [indent + line[0, last_at], line[last_at + 1, line.length]]
+      if last_at.nil?
+        [indent + line[0, width], line[width, line.length]]
+      else
+        [indent + line[0, last_at], line[last_at + 1, line.length]]
+      end
     end
 
     def available?


### PR DESCRIPTION
The line wrapping for strings longer than `width` was eating a character at the start of the next line. Here’s a sample buildnotes.md file:

```md
# Line wrap fix test

Fixing a missing character at the end of wrapped line with long no-whitespace strings

## Wrap test

long string long string long string long string long string long string long string long string long string long string long string long string long string long string 

longstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstring
```

And the output (I’m using `bat`) – note the missing character at the start of lines 8 and 9:
```
> ./howzit
───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ STDIN
───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ ╌╌( Wrap test )╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
   2   │
   3   │ long string long string long string long string long string long string long
   4   │ string long string long string long string long string long string long string
   5   │ long string
   6   │
   7   │ longstringlongstringlongstringlongstringlongstringlongstringlongstringlongstring
   8   │ ongstringlongstringlongstringlongstringlongstringlongstringlongstringlongstringl
   9   │ ngstringlongstring
───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────
```

With the fix:
```
> ./howzit
───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ STDIN
───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────
   1   │ ╌╌( Wrap test )╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
   2   │
   3   │ long string long string long string long string long string long string long
   4   │ string long string long string long string long string long string long string
   5   │ long string
   6   │
   7   │ longstringlongstringlongstringlongstringlongstringlongstringlongstringlongstring
   8   │ longstringlongstringlongstringlongstringlongstringlongstringlongstringlongstring
   9   │ longstringlongstring
───────┴────────────────────────────────────────────────────────────────────────────────────────────────────────
```

The original code presumed that the first character of the “remaining” string would be a space, which isn’t the case when `last_at.nil?`. It’s not the most glamorous fix, but it sorted the problem for me. :)
